### PR TITLE
chore: update dependencies

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -61,11 +61,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1765472234,
-        "narHash": "sha256-9VvC20PJPsleGMewwcWYKGzDIyjckEz8uWmT0vCDYK0=",
+        "lastModified": 1765779637,
+        "narHash": "sha256-KJ2wa/BLSrTqDjbfyNx70ov/HdgNBCBBSQP3BIzKnv4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2fbfb1d73d239d2402a8fe03963e37aab15abe8b",
+        "rev": "1306659b587dc277866c7b69eb97e5f07864d8c4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated dependency updates.

This PR may include:
- Nix flake input updates (`flake.lock`)
- Bun dependency updates (`bun.lock`)

This PR was created by the daily dependency update workflow.